### PR TITLE
Verbose mode, exec command from the config, pipeline execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 *.dll
 *.so
 *.dylib
+*.csv
+.DS_Store
 
 # Test binary, built with `go test -c`
 *.test

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Available Commands:
   list        List discovered domains
 
 Flags:
-  -h, --help   help for bbounty
+  -h, --help      help for bbounty
+  -v, --verbose   Verbose mode
 
 Use "bbounty [command] --help" for more information about a command.
 
@@ -39,7 +40,7 @@ hackertwo.com
 
 The following structure was just created:
 
-```
+```fish
 ❯ tree bbp -n 3
 bbp
 └── HackerOne
@@ -66,7 +67,7 @@ hackertwo.com
 ## Unix pipeline
 
 ```
-~ ❯ cat hackerone.csv | grep URL | cut -d, -f1 | bbounty add -p bbp -n HackerOne
+~ ❯ cat hackerone.csv | grep URL | cut -d, -f1 | bbounty --verbose add -p bbp -n HackerOne
 Enter domain names (press Enter to finish):
 Executing: echo ma.hacker.one | tee domains.txt
 ma.hacker.one
@@ -82,7 +83,7 @@ hackathon-photos.hackerone-user-content.com
 
 You can set a custom command line that will be triggered when you add a new program with the `add` command.
 
-```
+```bash
 ~ ❯ cat  ~/.config/bbounty/config.yml
 command: "echo %s | tee domains.txt"
 ```

--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ Flags:
 Use "bbounty [command] --help" for more information about a command.
 
 ~ ❯ bbounty add
-Enter program type (vdp or bbp): bbp
+Enter program type (vdp or bbp): vdp
 Enter program name: HackerOne
-Enter domain names (space-separated): hackerone.com hackertwo.com
+Enter domain names (press Enter to finish):
+hackerone.com
+hackertwo.com
 
 ... an output from subfinder with domains it discovered
 ```
@@ -29,7 +31,10 @@ Enter domain names (space-separated): hackerone.com hackertwo.com
 Alternatively, you can specify the program type and name using these options.
 ```bash
 ~ ❯ bbounty add -p bbp -n HackerOne
-Enter domain names (space-separated): hackerone.com hackertwo.com
+Enter domain names (press Enter to finish):
+hackerone.com
+hackertwo.com
+
 ```
 
 The following structure was just created:
@@ -57,6 +62,31 @@ mta-sts.forwarding.hackerone.com
 ...
 hackertwo.com
 ```
+
+## Unix pipeline
+
+```
+~ ❯ cat hackerone.csv | grep URL | cut -d, -f1 | bbounty add -p bbp -n HackerOne
+Enter domain names (press Enter to finish):
+Executing: echo ma.hacker.one | tee domains.txt
+ma.hacker.one
+
+Executing: echo support.hackerone.com | tee domains.txt
+support.hackerone.com
+
+Executing: echo hackathon-photos.hackerone-user-content.com | tee domains.txt
+hackathon-photos.hackerone-user-content.com
+```
+
+# Config
+
+You can set a custom command line that will be triggered when you add a new program with the `add` command.
+
+```
+~ ❯ cat  ~/.config/bbounty/config.yml
+command: "echo %s | tee domains.txt"
+```
+
 
 # Install
 

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,5 @@ require github.com/spf13/cobra v1.8.1
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/paractmol/bbounty
 
-go 1.22.5
+go 1.22
 
 retract v0.0.0-20240820202509-16ae89a324f7
 

--- a/go.sum
+++ b/go.sum
@@ -7,4 +7,5 @@ github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3k
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -14,9 +14,11 @@ import (
 )
 
 // execCommand executes a shell command in the specified directory with the given domain and command template.
-func execCommand(directory string, domain string, commandTemplate string) {
+func execCommand(directory string, domain string, commandTemplate string, verbose bool) {
 	commandString := fmt.Sprintf(commandTemplate, domain)
-	fmt.Println("Executing: " + commandString)
+	if verbose {
+		fmt.Println("Executing: " + commandString)
+	}
 	command := exec.Command("sh", "-c", commandString)
 	command.Dir = directory
 	var out bytes.Buffer
@@ -85,6 +87,7 @@ type CommandConfig struct {
 func loadCommandConfig(filename string) (string, error) {
 	var config CommandConfig
 	file, err := os.ReadFile(filename)
+
 	if err != nil {
 		return "", err // Return error if the file cannot be read
 	}
@@ -116,12 +119,15 @@ func main() {
 	}
 
 	var rootCmd = &cobra.Command{Use: "bbounty"}
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Verbose mode")
+
 	var addCmd = &cobra.Command{
 		Use:   "add",
 		Short: "Add a program with domain names",
 		Run: func(cmd *cobra.Command, args []string) {
 			programType, _ := cmd.Flags().GetString("program")
 			programName, _ := cmd.Flags().GetString("name")
+			verbose, _ := cmd.Flags().GetBool("verbose")
 
 			// Prompt for program type if not provided
 			if programType == "" {
@@ -158,7 +164,7 @@ func main() {
 
 			// Execute the command for each domain
 			for i, domain := range domains {
-				execCommand(programs[i], domain, commandTemplate)
+				execCommand(programs[i], domain, commandTemplate, verbose)
 			}
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -10,21 +10,15 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
-func promptUser(prompt string) string {
-	fmt.Print(prompt)
-	scanner := bufio.NewScanner(os.Stdin)
-	scanner.Scan()
-	return scanner.Text()
-}
-
-func createDirectoryStructure(programType, programName, domain string) {
-	directoryPath := fmt.Sprintf("%s/%s/%s", programType, programName, domain)
-	os.MkdirAll(directoryPath, 0755)
-
-	command := exec.Command("sh", "-c", fmt.Sprintf("subfinder -d %s --all | tee domains.txt", domain))
-	command.Dir = directoryPath
+// execCommand executes a shell command in the specified directory with the given domain and command template.
+func execCommand(directory string, domain string, commandTemplate string) {
+	commandString := fmt.Sprintf(commandTemplate, domain)
+	fmt.Println("Executing: " + commandString)
+	command := exec.Command("sh", "-c", commandString)
+	command.Dir = directory
 	var out bytes.Buffer
 	command.Stdout = &out
 	err := command.Run()
@@ -36,15 +30,34 @@ func createDirectoryStructure(programType, programName, domain string) {
 	fmt.Printf("%s\n", out.String())
 }
 
-func addProgram(programType, programName string) {
-	domainsInput := promptUser("Enter domain names (space-separated): ")
-	domains := strings.Fields(domainsInput)
-
-	for _, domain := range domains {
-		createDirectoryStructure(programType, programName, domain)
-	}
+// promptUser prompts the user for input and returns the response.
+func promptUser(prompt string) string {
+	fmt.Print(prompt)
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Scan()
+	return scanner.Text()
 }
 
+// createDirectoryStructure creates the directory structure for the program.
+func createDirectoryStructure(programType, programName, domain string) string {
+	directoryPath := fmt.Sprintf("%s/%s/%s", programType, programName, domain)
+	os.MkdirAll(directoryPath, 0755)
+	return directoryPath
+}
+
+// addProgram creates directories for each domain and returns a slice of created directories.
+func addProgram(programType, programName string, domains []string) []string {
+	directories := []string{}
+
+	for _, domain := range domains {
+		dir := createDirectoryStructure(programType, programName, domain)
+		directories = append(directories, dir) // Only append the directory
+	}
+
+	return directories
+}
+
+// discoveredDomains lists discovered domains in the current directory.
 func discoveredDomains() error {
 	err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -60,14 +73,48 @@ func discoveredDomains() error {
 		return nil
 	})
 
+	return err
+}
+
+// CommandConfig holds the command configuration.
+type CommandConfig struct {
+	Command string `yaml:"command"`
+}
+
+// loadCommandConfig loads the command configuration from a YAML file.
+func loadCommandConfig(filename string) (string, error) {
+	var config CommandConfig
+	file, err := os.ReadFile(filename)
 	if err != nil {
-		return err
+		return "", err // Return error if the file cannot be read
 	}
 
-	return nil
+	err = yaml.Unmarshal(file, &config)
+	if err != nil {
+		return "", err // Return error if unmarshaling fails
+	}
+	return config.Command, nil // Return the command string
 }
 
 func main() {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Println("Error getting home directory:", err)
+		return
+	}
+	filePath := filepath.Join(homeDir, ".config/bbounty/config.yml")
+
+	commandTemplate, err := loadCommandConfig(filePath)
+	if err != nil {
+		fmt.Println("Error loading command configuration:", err)
+		return
+	}
+
+	// Default to using subfinder if no command is specified
+	if commandTemplate == "" {
+		commandTemplate = "subfinder -d %s --all | tee domains.txt"
+	}
+
 	var rootCmd = &cobra.Command{Use: "bbounty"}
 	var addCmd = &cobra.Command{
 		Use:   "add",
@@ -76,13 +123,43 @@ func main() {
 			programType, _ := cmd.Flags().GetString("program")
 			programName, _ := cmd.Flags().GetString("name")
 
+			// Prompt for program type if not provided
 			if programType == "" {
 				programType = promptUser("Enter program type (vdp or bbp): ")
 			}
+
+			// Prompt for program name if not provided
 			if programName == "" {
 				programName = promptUser("Enter program name: ")
 			}
-			addProgram(programType, programName)
+
+			var domains []string
+			scanner := bufio.NewScanner(os.Stdin)
+
+			fmt.Println("Enter domain names (press Enter to finish):")
+
+			// Read domains from standard input
+			for scanner.Scan() {
+				line := scanner.Text() // Get the current line
+				if line == "" {
+					break // Stop reading on empty line
+				}
+				domains = append(domains, strings.Fields(line)...)
+			}
+
+			// If no domains were read from stdin, prompt the user for them
+			if len(domains) == 0 {
+				domainsInput := promptUser("Enter domain names (space-separated): ")
+				domains = strings.Fields(domainsInput)
+			}
+
+			// Create directories for all domains
+			programs := addProgram(programType, programName, domains)
+
+			// Execute the command for each domain
+			for i, domain := range domains {
+				execCommand(programs[i], domain, commandTemplate)
+			}
 		},
 	}
 	addCmd.Flags().StringP("program", "p", "", "Specify the program type (vdp or bbp)")

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Test for createDirectoryStructure
+func TestCreateDirectoryStructure(t *testing.T) {
+	programType := "testType"
+	programName := "testProgram"
+	domain := "testDomain"
+
+	expectedPath := filepath.Join(programType, programName, domain)
+
+	// Call the function
+	actualPath := createDirectoryStructure(programType, programName, domain)
+
+	// Check if the directory was created correctly
+	if actualPath != expectedPath {
+		t.Errorf("Expected path %s, but got %s", expectedPath, actualPath)
+	}
+
+	// Clean up the created directory
+	defer os.RemoveAll(filepath.Join(programType))
+}
+
+// Test for addProgram
+func TestAddProgram(t *testing.T) {
+	programType := "testType"
+	programName := "testProgram"
+	domains := []string{"domain1.com", "domain2.com"}
+
+	// Call the function
+	directories := addProgram(programType, programName, domains)
+
+	// Check if the directories were created correctly
+	for i, domain := range domains {
+		expectedPath := filepath.Join(programType, programName, domain)
+		if directories[i] != expectedPath {
+			t.Errorf("Expected path %s, but got %s", expectedPath, directories[i])
+		}
+	}
+
+	// Clean up the created directories
+	defer os.RemoveAll(filepath.Join(programType))
+}
+
+// Test for loadCommandConfig
+func TestLoadCommandConfig(t *testing.T) {
+	// Create a temporary YAML file for testing
+	tempFile, err := os.CreateTemp("", "config.yml")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tempFile.Name()) // Clean up
+
+	// Write test content to the temp file
+	testContent := "command: \"echo %s\"\n"
+	if _, err := tempFile.WriteString(testContent); err != nil {
+		t.Fatalf("Failed to write to temp file: %v", err)
+	}
+
+	// Close the file
+	tempFile.Close()
+
+	// Load the command from the temp file
+	command, err := loadCommandConfig(tempFile.Name())
+	if err != nil {
+		t.Fatalf("Error loading command configuration: %v", err)
+	}
+
+	// Check if the command is as expected
+	expectedCommand := "echo %s"
+	if command != expectedCommand {
+		t.Errorf("Expected command %s, but got %s", expectedCommand, command)
+	}
+
+	defer os.Remove(tempFile.Name()) // Add this to clean up the temporary file
+}


### PR DESCRIPTION
- Add verbose mode
- Set the desired command to execute from the `~/.config/bbounty/config.yml`
- Allow Unix pipelines to work, making it possible to execute commands such as `cat hackerone.csv | grep URL | cut -d, -f1 | bbounty --verbose add -p bbp -n HackerOne`
- Add boilerplate tests
- Improve documentation